### PR TITLE
Updating to a more recent version of Burst

### DIFF
--- a/Ghost-Hunter/Packages/manifest.json
+++ b/Ghost-Hunter/Packages/manifest.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "com.unity.ai.navigation": "1.1.3",
+    "com.unity.burst": "1.8.4",
     "com.unity.collab-proxy": "2.0.0",
     "com.unity.feature.2d": "1.0.0",
     "com.unity.ide.rider": "3.0.18",

--- a/Ghost-Hunter/Packages/packages-lock.json
+++ b/Ghost-Hunter/Packages/packages-lock.json
@@ -92,8 +92,8 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.burst": {
-      "version": "1.8.2",
-      "depth": 1,
+      "version": "1.8.4",
+      "depth": 0,
       "source": "registry",
       "dependencies": {
         "com.unity.mathematics": "1.2.1"


### PR DESCRIPTION
Burst has a bug that causes compile errors, but updating to a more recent version seems to solve them